### PR TITLE
remove duplicate and uncommented copyright

### DIFF
--- a/scripts/build_tena_adapters/buildTenaAdapters.sh
+++ b/scripts/build_tena_adapters/buildTenaAdapters.sh
@@ -30,23 +30,6 @@ tenaVersion=6.0.7
 tenaBuildVersion=u1804-gcc75-64
 tenaSourceScript=$localTenaDir/$tenaVersion/scripts/tenaenv-$tenaBuildVersion-v$tenaVersion.sh
 #--------------------------------------------------------#
-/*                                                                              
- * Copyright (C) 2019-2021 LEIDOS.                                              
- *                                                                              
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not  
- * use this file except in compliance with the License. You may obtain a copy o\
-f                                                                               
- * the License at                                                               
- *                                                                              
- * http://www.apache.org/licenses/LICENSE-2.0                                   
- *                                                                              
- * Unless required by applicable law or agreed to in writing, software          
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT    
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the     
- * License for the specific language governing permissions and limitations unde\
-r                                                                               
- * the License.                                                                 
- */
 
 #-------------------| REMOTE VARIABLES |-------------------#
 #-------------------|  DO NOT CHANGE   |-------------------#


### PR DESCRIPTION
# PR Details
## Description

The uncommented copyright notice causes an error when running `buildTenaAdapters.sh`. The notice is also a duplicate of the notice at the top of the file so I just removed it.

## Related Issue

## Motivation and Context

Running `$ ./buildTenaAdapters.sh` causes this error due to the uncommented copyright notice

```
./buildTenaAdapters.sh: line 33: /bin: Is a directory
./buildTenaAdapters.sh: line 34: syntax error near unexpected token `('
./buildTenaAdapters.sh: line 34: ` * Copyright (C) 2019-2021 LEIDOS.       
```

## How Has This Been Tested?

This was tested by running the bash script with the commited changes.
