### PR TITLE
Remove set_time_mode.py execution from runCarmaSim script

### DIFF
--- a/scripts/run_scripts/demo1/constructive_node/runCarmaSim.sh
+++ b/scripts/run_scripts/demo1/constructive_node/runCarmaSim.sh
@@ -46,7 +46,7 @@ date >> $SIM_LOG
 $localCarlaPath/CarlaUE4.sh &>> $CARLA_LOG &
 sleep 5
 
-python3 $voicesPocPath/scripts/carla_python_scripts/set_time_mode.py
+#python3 $voicesPocPath/scripts/carla_python_scripts/set_time_mode.py
 
 
 docker run \


### PR DESCRIPTION
During SIT1 test preparation, it was found that the set_time_mode.py script had to be updated (these updates were included in PR #5) to enable simulation time to match real time. Due to these changes, the set_time_mode.py script cannot be executed from within RunCarmaSim.sh. This PR includes that update to RunCarmaSim.sh.