### PR TITLE
[Future Work] Unify the build scripts and streamline variables

### DIFF
--- a/docker/build/README.md
+++ b/docker/build/README.md
@@ -1,0 +1,30 @@
+# build
+
+Dockerfiles and build scripts for the dt-* images.
+
+**Main entry point: `build-image.sh`** — builds any image by name (see `./build-image.sh --help`).
+Following tree shows which script uses which files.
+
+```text
+build-image.sh                            # main entry point; dispatches to one Dockerfile below
+├── usdotfhwastol_token                   # secret file, mounted for build-general and v2xhub
+├── build-assets.env/build-assets_*.env   # sets BUILD_DIR; sourced for base, core, v2xhub
+│   └── (populated by fetch-assets.sh, which needs to be run manually beforehand)
+│
+├── dt-base_Dockerfile               # FROM ubuntu:22.04
+│   ├── dt-build-general_Dockerfile  # FROM dt-base
+│   │   └── dt-build-carla_Dockerfile  # FROM dt-build-general
+│   └── dt-core_Dockerfile           # FROM dt-base
+│       └── lib/COPY                 # copied in
+│
+├── dt-v2xhub_Dockerfile             # FROM dt-build-v2xhub (external, hand-committed image; see file header)
+│   └── checkout.bash                # copied in, clones vug-v2xhub-v2x-plugin using USDOTFHWASTOL_TOKEN
+│
+├── dt-carla_Dockerfile              # FROM carlasim/carla:0.9.10
+│   └── lib/MAPS, lib/CARLA_TFHRC, lib/COPY   # mounted/copied in
+│
+└── dt-carla-0-9-15_Dockerfile       # FROM carlasim/carla:0.9.15
+    └── lib/MAPS_915, lib/COPY       # mounted/copied in
+```
+
+NOTE: Each `dt-*_Dockerfile` also documents its own raw `docker build` command at the top, in case you need to build it directly without the wrapper

--- a/docker/build/README.md
+++ b/docker/build/README.md
@@ -18,7 +18,13 @@ build-image.sh                            # main entry point; dispatches to one 
 │       └── lib/COPY                 # copied in
 │
 ├── dt-v2xhub_Dockerfile             # FROM dt-build-v2xhub (external, hand-committed image; see file header)
-│   └── checkout.bash                # copied in, clones vug-v2xhub-v2x-plugin using USDOTFHWASTOL_TOKEN
+│   ├── checkout.bash                # copied in, clones vug-v2xhub-v2x-plugin using USDOTFHWASTOL_TOKEN
+│   └── stages: assets -> base -> runtime (default)
+│       # "base" has TENA/DIST installed but no plugin baked in - always builds even if the
+│       # plugin is broken. Build it directly with `./build-image.sh v2xhub -v DEV --target base`
+│       # for a devcontainer; mount your local plugin checkout in and build/debug interactively.
+│       # "runtime" (the default target) additionally clones and builds the plugin - this is
+│       # the deployable dt-v2xhub image, and only builds when the plugin builds cleanly.
 │
 ├── dt-carla_Dockerfile              # FROM carlasim/carla:0.9.10
 │   └── lib/MAPS, lib/CARLA_TFHRC, lib/COPY   # mounted/copied in

--- a/docker/build/build-image.sh
+++ b/docker/build/build-image.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+
+# Unified build script for the dt-*_Dockerfile images in this directory.
+# Wraps the differing `docker build` invocations documented at the top of
+# each dt-*_Dockerfile (build-context assets, secrets, tag naming) behind one
+# consistent interface.
+#
+# Usage: ./build-image.sh <image> -v VERSION [options]
+#
+#   <image>            One of: base, build-general, build-carla, core, v2xhub, carla, carla-0-9-15
+#   -v, --version      Image version tag (required)
+#   --plugin-branch    v2xhub only: vug-v2xhub-v2x-plugin branch to build (default develop)
+#   --tag-latest       Also tag the image as :latest
+#   -h, --help         Show this help
+#
+# Environment variables:
+#   DOCKER_ORG   Harbor org/project the built image is tagged under, and that
+#                base-image FROM lines pull dt-* images from, e.g.
+#                "distributed-testing" (default) or "distributed-testing-dev"
+#   DOCKER_TAG   Tag to pull dt-* base images at, e.g. "latest" (default) or "0.0.1"
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+REGISTRY_HOST="harbor.distributedtesting.org"
+DOCKER_ORG="${DOCKER_ORG:-distributed-testing}"
+DOCKER_TAG="${DOCKER_TAG:-latest}"
+REGISTRY="${REGISTRY_HOST}/${DOCKER_ORG}"
+TOKEN_FILE="usdotfhwastol_token"
+ASSETS_ENV="build-assets.env"
+
+declare -A DOCKERFILE=(
+      [base]="dt-base_Dockerfile"
+      [build-general]="dt-build-general_Dockerfile"
+      [build-carla]="dt-build-carla_Dockerfile"
+      [core]="dt-core_Dockerfile"
+      [v2xhub]="dt-v2xhub_Dockerfile"
+      [carla]="dt-carla_Dockerfile"
+      [carla-0-9-15]="dt-carla-0-9-15_Dockerfile"
+)
+
+# Harbor repo name each image key publishes under (carla-0-9-15 shares dt-carla,
+# distinguished by tag prefix below)
+declare -A IMAGE_NAME=(
+      [base]="dt-base"
+      [build-general]="dt-build-general"
+      [build-carla]="dt-build-carla"
+      [core]="dt-core"
+      [v2xhub]="dt-v2xhub"
+      [carla]="dt-carla"
+      [carla-0-9-15]="dt-carla"
+)
+
+declare -A TAG_PREFIX=(
+      [carla-0-9-15]="0-9-15-"
+)
+
+# Images whose Dockerfile mounts the shared "assets" build-context (populated
+# via build-assets.env + fetch-assets.sh)
+declare -A NEEDS_ASSETS=(
+      [base]=1
+      [core]=1
+      [v2xhub]=1
+)
+
+# Images whose Dockerfile mounts the usdotfhwastol_token secret
+declare -A NEEDS_SECRET=(
+      [build-general]=1
+      [v2xhub]=1
+)
+
+# Images whose Dockerfile FROMs another dt-* image via ARG DOCKER_ORG/DOCKER_TAG
+declare -A USES_ORG_TAG=(
+      [build-general]=1
+      [build-carla]=1
+      [core]=1
+      [v2xhub]=1
+)
+
+usage() {
+      echo "Usage: $0 <image> -v VERSION [options]"
+      echo
+      echo "  image            one of: ${!DOCKERFILE[*]}"
+      echo "  -v, --version    image version tag (required)"
+      echo "  --plugin-branch  v2xhub only: vug-v2xhub-v2x-plugin branch to build (default develop)"
+      echo "  --tag-latest     also tag the image as :latest"
+      echo "  -h, --help       show this help"
+      exit 1
+}
+
+if [[ $# -eq 0 ]]; then
+      usage
+fi
+
+IMAGE="$1"
+shift
+
+VERSION=""
+PLUGIN_BRANCH="develop"
+TAG_LATEST=0
+
+while [[ $# -gt 0 ]]; do
+      arg="$1"
+      case $arg in
+            -v|--version)
+                  VERSION="$2"
+                  shift
+                  shift
+            ;;
+            --plugin-branch)
+                  PLUGIN_BRANCH="$2"
+                  shift
+                  shift
+            ;;
+            --tag-latest)
+                  TAG_LATEST=1
+                  shift
+            ;;
+            -h|--help)
+                  usage
+            ;;
+            *)
+                  echo "Unknown argument: $1" >&2
+                  usage
+            ;;
+      esac
+done
+
+if [[ -z "${DOCKERFILE[$IMAGE]:-}" ]]; then
+      echo "Unknown image '$IMAGE'. Must be one of: ${!DOCKERFILE[*]}" >&2
+      exit 1
+fi
+
+if [[ -z "$VERSION" ]]; then
+      echo "Missing required -v/--version" >&2
+      usage
+fi
+
+DOCKERFILE_PATH="${DOCKERFILE[$IMAGE]}"
+TAG="${TAG_PREFIX[$IMAGE]:-}${VERSION}"
+FULL_TAG="${REGISTRY}/${IMAGE_NAME[$IMAGE]}:${TAG}"
+
+BUILD_ARGS=(--build-arg "VERSION=${VERSION}")
+EXTRA_ARGS=()
+
+if [[ "${NEEDS_ASSETS[$IMAGE]:-0}" -eq 1 ]]; then
+      # shellcheck disable=SC1090
+      source "$ASSETS_ENV"
+      if [[ -z "${BUILD_DIR:-}" ]]; then
+            echo "BUILD_DIR not set by $ASSETS_ENV" >&2
+            exit 1
+      fi
+      EXTRA_ARGS+=(--build-context "assets=$BUILD_DIR")
+fi
+
+if [[ "${NEEDS_SECRET[$IMAGE]:-0}" -eq 1 ]]; then
+      if [[ ! -f "$TOKEN_FILE" ]]; then
+            echo "Missing $TOKEN_FILE - see the secret instructions at the top of dt-v2xhub_Dockerfile" >&2
+            exit 1
+      fi
+      EXTRA_ARGS+=(--secret "id=usdotfhwastol_token,src=$TOKEN_FILE")
+fi
+
+if [[ "$IMAGE" == "v2xhub" ]]; then
+      BUILD_ARGS+=(--build-arg "PLUGIN_BRANCH=${PLUGIN_BRANCH}")
+fi
+
+if [[ "${USES_ORG_TAG[$IMAGE]:-0}" -eq 1 ]]; then
+      BUILD_ARGS+=(--build-arg "DOCKER_ORG=${DOCKER_ORG}" --build-arg "DOCKER_TAG=${DOCKER_TAG}")
+fi
+
+DOCKER_BUILDKIT=1 docker build \
+      "${EXTRA_ARGS[@]}" \
+      "${BUILD_ARGS[@]}" \
+      -t "$FULL_TAG" \
+      --progress=plain \
+      -f "$DOCKERFILE_PATH" \
+      .
+
+if [[ "$TAG_LATEST" -eq 1 ]]; then
+      LATEST_TAG="${REGISTRY}/${IMAGE_NAME[$IMAGE]}:latest"
+      docker tag "$FULL_TAG" "$LATEST_TAG"
+      echo "Tagged $LATEST_TAG"
+fi
+
+echo "Built $FULL_TAG"

--- a/docker/build/build-image.sh
+++ b/docker/build/build-image.sh
@@ -10,6 +10,9 @@
 #   <image>            One of: base, build-general, build-carla, core, v2xhub, carla, carla-0-9-15
 #   -v, --version      Image version tag (required)
 #   --plugin-branch    v2xhub only: vug-v2xhub-v2x-plugin branch to build (default develop)
+#   --target           Dockerfile stage to build, e.g. v2xhub's "base" (plugin not baked in,
+#                       always builds - use for a devcontainer) vs "runtime" (default; the
+#                       full deployable image, requires the plugin to build cleanly)
 #   --tag-latest       Also tag the image as :latest
 #   -h, --help         Show this help
 #
@@ -85,6 +88,7 @@ usage() {
       echo "  image            one of: ${!DOCKERFILE[*]}"
       echo "  -v, --version    image version tag (required)"
       echo "  --plugin-branch  v2xhub only: vug-v2xhub-v2x-plugin branch to build (default develop)"
+      echo "  --target         Dockerfile stage to build, e.g. v2xhub's 'base' vs 'runtime' (default)"
       echo "  --tag-latest     also tag the image as :latest"
       echo "  -h, --help       show this help"
       exit 1
@@ -99,6 +103,7 @@ shift
 
 VERSION=""
 PLUGIN_BRANCH="develop"
+TARGET=""
 TAG_LATEST=0
 
 while [[ $# -gt 0 ]]; do
@@ -111,6 +116,11 @@ while [[ $# -gt 0 ]]; do
             ;;
             --plugin-branch)
                   PLUGIN_BRANCH="$2"
+                  shift
+                  shift
+            ;;
+            --target)
+                  TARGET="$2"
                   shift
                   shift
             ;;
@@ -139,11 +149,15 @@ if [[ -z "$VERSION" ]]; then
 fi
 
 DOCKERFILE_PATH="${DOCKERFILE[$IMAGE]}"
-TAG="${TAG_PREFIX[$IMAGE]:-}${VERSION}"
+TAG="${TAG_PREFIX[$IMAGE]:-}${VERSION}${TARGET:+-$TARGET}"
 FULL_TAG="${REGISTRY}/${IMAGE_NAME[$IMAGE]}:${TAG}"
 
 BUILD_ARGS=(--build-arg "VERSION=${VERSION}")
 EXTRA_ARGS=()
+
+if [[ -n "$TARGET" ]]; then
+      EXTRA_ARGS+=(--target "$TARGET")
+fi
 
 if [[ "${NEEDS_ASSETS[$IMAGE]:-0}" -eq 1 ]]; then
       # shellcheck disable=SC1090

--- a/docker/build/checkout.bash
+++ b/docker/build/checkout.bash
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Generic checkout script for private usdot-fhwa-stol repos, used by Dockerfiles
+# to clone source at build time.
+# Requires USDOTFHWASTOL_TOKEN to be exported (private repo, cloned over HTTPS).
+#
+# Usage: checkout.bash <repo> [-b branch] [-r root]
+#   <repo>  Required. Repo name under github.com/usdot-fhwa-stol, e.g. vug-v2xhub-v2x-plugin
+#   -b/--branch  Branch to clone, default 'develop'
+#   -r/--root    Directory to clone into (must be empty/nonexistent), default is the current directory
+
+set -exo pipefail
+
+REPO=""
+dir="$(pwd)"
+BRANCH="develop"
+while [[ $# -gt 0 ]]; do
+      arg="$1"
+      case $arg in
+            -b|--branch)
+                  BRANCH=$2
+                  shift
+                  shift
+            ;;
+            -r|--root)
+                  dir=$2
+                  shift
+                  shift
+            ;;
+            *)
+                  REPO=$1
+                  shift
+            ;;
+      esac
+done
+
+if [[ -z "${REPO}" ]]; then
+      echo "Usage: checkout.bash <repo> [-b branch] [-r root]"
+      exit 1
+fi
+
+mkdir -p "${dir}"
+cd "${dir}"
+
+# Cloned directly into "${dir}" rather than a named subdirectory, since callers
+# (e.g. the TENA V2X Plugin's own build.sh) may hardcode their source root.
+git clone --depth=1 --branch "${BRANCH}" \
+      "https://${USDOTFHWASTOL_TOKEN}@github.com/usdot-fhwa-stol/${REPO}.git" \
+      .

--- a/docker/build/dt-build-carla_Dockerfile
+++ b/docker/build/dt-build-carla_Dockerfile
@@ -3,9 +3,14 @@
 # VERSION=0.0.2 && docker tag harbor.distributedtesting.org/distributed-testing/dt-build-carla:$VERSION harbor.distributedtesting.org/distributed-testing/dt-build-carla:latest
 #
 
-FROM harbor.distributedtesting.org/distributed-testing/dt-build-general:latest
+# Which harbor org/tag to pull the dt-build-general base image from, e.g. distributed-testing-dev:latest
+# vs distributed-testing:0.0.1. Overridable so this Dockerfile can build against a dev registry org.
+ARG DOCKER_ORG="distributed-testing"
+ARG DOCKER_TAG="latest"
 
-ARG DEBIAN_FRONTEND="noninteractive" 
+FROM harbor.distributedtesting.org/${DOCKER_ORG}/dt-build-general:${DOCKER_TAG}
+
+ARG DEBIAN_FRONTEND="noninteractive"
 ARG TZ="America/New_York"
 
 USER root

--- a/docker/build/dt-build-general_Dockerfile
+++ b/docker/build/dt-build-general_Dockerfile
@@ -1,4 +1,9 @@
-FROM harbor.distributedtesting.org/distributed-testing/dt-base:latest
+# Which harbor org/tag to pull the dt-base base image from, e.g. distributed-testing-dev:latest
+# vs distributed-testing:0.0.1. Overridable so this Dockerfile can build against a dev registry org.
+ARG DOCKER_ORG="distributed-testing"
+ARG DOCKER_TAG="latest"
+
+FROM harbor.distributedtesting.org/${DOCKER_ORG}/dt-base:${DOCKER_TAG}
 
 # Make sure that the docker container gets enough memory or the compiler will crash building the CppClient
 # On macos I increased the memory available from 2.0GB to 6.0GB.  I didn't try lower than this yet.

--- a/docker/build/dt-core_Dockerfile
+++ b/docker/build/dt-core_Dockerfile
@@ -2,8 +2,13 @@
 # BUILD COMMAND: VERSION=0.0.1 && source build-assets.env && DOCKER_BUILDKIT=1 docker build --build-arg version=$VERSION --build-context assets="$BUILD_DIR" -t harbor.distributedtesting.org/distributed-testing/dt-core:$VERSION . --progress=plain -f dt-core_Dockerfile
 #
 
+# Which harbor org/tag to pull the dt-base base image from, e.g. distributed-testing-dev:latest
+# vs distributed-testing:0.0.1. Overridable so this Dockerfile can build against a dev registry org.
+ARG DOCKER_ORG="distributed-testing"
+ARG DOCKER_TAG="latest"
+
 # ----------------------- BUILD STAGE ----------------------- #
-FROM harbor.distributedtesting.org/distributed-testing/dt-base:latest AS build
+FROM harbor.distributedtesting.org/${DOCKER_ORG}/dt-base:${DOCKER_TAG} AS build
 
 SHELL ["/bin/bash", "-ec"]
 
@@ -84,7 +89,7 @@ RUN --mount=type=bind,from=assets,source=.,target=/mnt/build,readonly \
     mv CARLA_0.9.15 $HOME/CARLA
 
 # ----------------------- RUNTIME STAGE ----------------------- #
-FROM harbor.distributedtesting.org/distributed-testing/dt-base:latest
+FROM harbor.distributedtesting.org/${DOCKER_ORG}/dt-base:${DOCKER_TAG}
 
 ARG VERSION=dev
 LABEL version=${VERSION}

--- a/docker/build/dt-v2xhub_Dockerfile
+++ b/docker/build/dt-v2xhub_Dockerfile
@@ -88,7 +88,7 @@ FROM base AS runtime
 
 USER root
 
-ARG PLUGIN_BRANCH="feature/dt-to-v2xhub-develop"
+ARG PLUGIN_BRANCH="develop"
 COPY checkout.bash /home/plugin/checkout.bash
 
 # Clone and build the TENA V2X Plugin using its own build.sh, which installs

--- a/docker/build/dt-v2xhub_Dockerfile
+++ b/docker/build/dt-v2xhub_Dockerfile
@@ -14,7 +14,7 @@
 ARG DOCKER_ORG="distributed-testing"
 ARG DOCKER_TAG="latest"
 
-FROM harbor.distributedtesting.org/${DOCKER_ORG}/dt-build-v2xhub:${DOCKER_TAG} AS build
+FROM harbor.distributedtesting.org/${DOCKER_ORG}/dt-build-v2xhub:${DOCKER_TAG} AS assets
 
 SHELL ["/bin/bash", "-ec"]
 
@@ -47,7 +47,11 @@ RUN --mount=type=bind,from=assets,source=.,target=/mnt/build,readonly \
     # move the postinst script into TENA dir to make it easier to copy and run later on final container
     mv ./postinst ./opt/TENA/postinst-DIST
 
-FROM harbor.distributedtesting.org/${DOCKER_ORG}/dt-build-v2xhub:${DOCKER_TAG}
+# "base" has TENA/DIST + the cmake package installed but no plugin baked in,
+# so it always builds even when the plugin itself is broken. Target this
+# stage directly (`docker build --target base`) for a devcontainer image;
+# mount your local plugin checkout into it and build/debug interactively.
+FROM harbor.distributedtesting.org/${DOCKER_ORG}/dt-build-v2xhub:${DOCKER_TAG} AS base
 
 SHELL ["/bin/bash", "-ec"]
 
@@ -56,7 +60,7 @@ WORKDIR /home/plugin
 USER root
 
 # Mounts files in a temporary space with rw perms, copies them to container, runs postinst scripts, changes ownership
-COPY --from=build --chown=plugin:nogroup /home/plugin/opt/TENA /home/plugin/TENA
+COPY --from=assets --chown=plugin:nogroup /home/plugin/opt/TENA /home/plugin/TENA
 RUN DSTROOT=/home/plugin ./TENA/postinst-MW
 RUN DSTROOT=/home/plugin ./TENA/postinst-DIST
 RUN mkdir /home/plugin/TENA/log
@@ -71,6 +75,19 @@ RUN --mount=type=secret,id=usdotfhwastol_token \
     mv cmake_temp/cmake/ /home/plugin/TENA/lib/ && \
 	rm -rf cmake_temp
 
+# Everything above ran as root and wrote into /home/plugin/TENA (postinst
+# scripts, the log dir, the cmake package), so re-assert ownership once here
+# rather than chowning after each step.
+RUN chown -R plugin:nogroup /home/plugin/TENA
+
+# "runtime" is the deployable image: it builds on "base" by baking in the
+# TENA V2X Plugin. It only builds successfully when the plugin itself builds
+# cleanly - for interactive plugin development/debugging, use the "base"
+# target above instead.
+FROM base AS runtime
+
+USER root
+
 ARG PLUGIN_BRANCH="feature/dt-to-v2xhub-develop"
 COPY checkout.bash /home/plugin/checkout.bash
 
@@ -83,11 +100,6 @@ RUN --mount=type=secret,id=usdotfhwastol_token \
     cd /workspace && chmod +x build.sh && ./build.sh && \
     chown -R plugin:nogroup /usr/local/plugins && \
     rm -rf /workspace
-
-# Everything above ran as root and wrote into /home/plugin/TENA (postinst
-# scripts, the log dir, the cmake package), so re-assert ownership once here
-# rather than chowning after each step.
-RUN chown -R plugin:nogroup /home/plugin/TENA
 
 USER plugin
 

--- a/docker/build/dt-v2xhub_Dockerfile
+++ b/docker/build/dt-v2xhub_Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /home/plugin
 USER root
 
 # Mounts files in a temporary space with rw perms, copies them to container, runs postinst scripts, changes ownership
-COPY --from=build --chown=plugin:plugin /home/plugin/opt/TENA /home/plugin/TENA
+COPY --from=build --chown=plugin:nogroup /home/plugin/opt/TENA /home/plugin/TENA
 RUN DSTROOT=/home/plugin ./TENA/postinst-MW
 RUN DSTROOT=/home/plugin ./TENA/postinst-DIST
 RUN mkdir /home/plugin/TENA/log
@@ -81,13 +81,13 @@ RUN --mount=type=secret,id=usdotfhwastol_token \
     export USDOTFHWASTOL_TOKEN=$(cat /run/secrets/usdotfhwastol_token) && \
     ./checkout.bash vug-v2xhub-v2x-plugin -b "${PLUGIN_BRANCH}" -r /workspace && \
     cd /workspace && chmod +x build.sh && ./build.sh && \
-    chown -R plugin:plugin /usr/local/plugins && \
+    chown -R plugin:nogroup /usr/local/plugins && \
     rm -rf /workspace
 
 # Everything above ran as root and wrote into /home/plugin/TENA (postinst
 # scripts, the log dir, the cmake package), so re-assert ownership once here
 # rather than chowning after each step.
-RUN chown -R plugin:plugin /home/plugin/TENA
+RUN chown -R plugin:nogroup /home/plugin/TENA
 
 USER plugin
 

--- a/docker/build/dt-v2xhub_Dockerfile
+++ b/docker/build/dt-v2xhub_Dockerfile
@@ -9,7 +9,12 @@
 # Make a file named `usdotfhwastol_token` under distributed-testing/docker/
 # Copy your token into that file
 
-FROM harbor.distributedtesting.org/distributed-testing/dt-build-v2xhub:latest AS build
+# Which harbor org/tag to pull the dt-build-v2xhub base image from, e.g. distributed-testing-dev:latest
+# vs distributed-testing:0.0.1. Overridable so this Dockerfile can build against a dev registry org.
+ARG DOCKER_ORG="distributed-testing"
+ARG DOCKER_TAG="latest"
+
+FROM harbor.distributedtesting.org/${DOCKER_ORG}/dt-build-v2xhub:${DOCKER_TAG} AS build
 
 SHELL ["/bin/bash", "-ec"]
 
@@ -20,7 +25,7 @@ USER root
 RUN apt-get update && \
     apt-get install -y python3-pip \
     # add some build packages
-    zstd 
+    zstd
 
 ARG TENA_VERSION="TENA-MiddlewareSDK-v6.0.11"
 # INSTALL TENA deb
@@ -30,7 +35,7 @@ RUN --mount=type=bind,from=assets,source=.,target=/mnt/build,readonly \
     ar -x /mnt/build/${TENA_VERSION}@Product@u2204-gcc11-64-*.deb && \
     tar xf control.tar.* && \
     # move the postinst script into TENA dir to make it easier to copy and run later on final container
-    mv ./postinst ./opt/TENA/postinst-MW 
+    mv ./postinst ./opt/TENA/postinst-MW
 
 ARG DIST_VERSION="VUG-Combined-Distribution-v1.3.3"
 # Install DT OMs
@@ -42,7 +47,9 @@ RUN --mount=type=bind,from=assets,source=.,target=/mnt/build,readonly \
     # move the postinst script into TENA dir to make it easier to copy and run later on final container
     mv ./postinst ./opt/TENA/postinst-DIST
 
-FROM harbor.distributedtesting.org/distributed-testing/dt-build-v2xhub:latest
+FROM harbor.distributedtesting.org/${DOCKER_ORG}/dt-build-v2xhub:${DOCKER_TAG}
+
+SHELL ["/bin/bash", "-ec"]
 
 WORKDIR /home/plugin
 
@@ -62,7 +69,25 @@ RUN --mount=type=secret,id=usdotfhwastol_token \
     USDOTFHWASTOL_TOKEN=$(cat /run/secrets/usdotfhwastol_token) && \
     git clone https://${USDOTFHWASTOL_TOKEN}@github.com/usdot-fhwa-stol/vug-cmake-package.git cmake_temp && \
     mv cmake_temp/cmake/ /home/plugin/TENA/lib/ && \
-	rm -rf cmake_temp  
+	rm -rf cmake_temp
+
+ARG PLUGIN_BRANCH="feature/dt-to-v2xhub-develop"
+COPY checkout.bash /home/plugin/checkout.bash
+
+# Clone and build the TENA V2X Plugin using its own build.sh, which installs
+# straight into /usr/local/plugins so the image ships with it baked in.
+# Delete the source code after building to keep the image size down.
+RUN --mount=type=secret,id=usdotfhwastol_token \
+    export USDOTFHWASTOL_TOKEN=$(cat /run/secrets/usdotfhwastol_token) && \
+    ./checkout.bash vug-v2xhub-v2x-plugin -b "${PLUGIN_BRANCH}" -r /workspace && \
+    cd /workspace && chmod +x build.sh && ./build.sh && \
+    chown -R plugin:plugin /usr/local/plugins && \
+    rm -rf /workspace
+
+# Everything above ran as root and wrote into /home/plugin/TENA (postinst
+# scripts, the log dir, the cmake package), so re-assert ownership once here
+# rather than chowning after each step.
+RUN chown -R plugin:plugin /home/plugin/TENA
 
 USER plugin
 
@@ -70,11 +95,8 @@ ARG VERSION=dev
 LABEL version=${VERSION}
 LABEL description="V2XHub Distributed Testing Docker Image"
 
-# Once you have the built TENA V2X Plugin, uncomment the line below to copy it directly into the Docker image
-# COPY lib/TenaV2Xplugin.zip /usr/local/plugins/TenaV2Xplugin.zip
-
 RUN echo 'source /home/plugin/TENA/6.0.11/scripts/tenaenv-u2204-gcc11-64-v6.0.11.sh' >> /home/plugin/.bashrc
 
-WORKDIR /var/log/tmx 
+WORKDIR /var/log/tmx
 
 ENTRYPOINT ["/usr/local/bin/service.sh"]

--- a/docker/build/dt-v2xhub_Dockerfile
+++ b/docker/build/dt-v2xhub_Dockerfile
@@ -14,7 +14,7 @@
 ARG DOCKER_ORG="distributed-testing"
 ARG DOCKER_TAG="latest"
 
-FROM harbor.distributedtesting.org/${DOCKER_ORG}/dt-build-v2xhub:${DOCKER_TAG} AS assets
+FROM harbor.distributedtesting.org/${DOCKER_ORG}/dt-build-v2xhub:${DOCKER_TAG} AS extract
 
 SHELL ["/bin/bash", "-ec"]
 
@@ -60,7 +60,7 @@ WORKDIR /home/plugin
 USER root
 
 # Mounts files in a temporary space with rw perms, copies them to container, runs postinst scripts, changes ownership
-COPY --from=assets --chown=plugin:nogroup /home/plugin/opt/TENA /home/plugin/TENA
+COPY --from=extract --chown=plugin:nogroup /home/plugin/opt/TENA /home/plugin/TENA
 RUN DSTROOT=/home/plugin ./TENA/postinst-MW
 RUN DSTROOT=/home/plugin ./TENA/postinst-DIST
 RUN mkdir /home/plugin/TENA/log


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR adds following unifying processes:
- `docker/build/build-image.sh` added — single docker build wrapper for all dt-*_Dockerfiles, replacing per-image manual docker build invocations. 
  - Why: the per-Dockerfile build commands (assets context, secrets, tags) had drifted and were easy to get wrong by hand; one script with --help centralizes that.
- Dockerfiles parametrized with `ARG DOCKER_ORG/DOCKER_TAG` (dt-build-general, dt-build-carla, dt-core, dt-v2xhub) - `base-image FROM` lines now pull from a configurable registry org/tag instead of a hardcoded `distributed-testing:latest`. 
  - Why: lets the same Dockerfiles build against a dev registry (distributed-testing-dev) or pinned version without editing the file.
- `dt-v2xhub_Dockerfile` now builds the TENA V2X Plugin in-image via new `docker/build/checkout.bash` (generic private-repo checkout helper) instead of requiring a manually-built plugin zip to be copied in. It also have different targets, such as only base (no plugin) or runtime (with plugin)
  - Why: bakes plugin build into the image so it's reproducible from source rather than a locally-produced artifact.
- `docker/build/README.md` added: documents build-image.sh as the entry point and maps out the Dockerfile FROM hierarchy and supporting files. 
  - Why: onboarding doc for the new unified workflow above.

NOTE: All these changes should help when we are ready to do CI/CD so we are not manually pushing the images ourselves which may be prone to error and difficult to track across many users

<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/HASS-645
<!-- e.g. CAR-123 -->

## Motivation and Context
Currently, there are two teams working on DT related projects and setting up the devcontainer right seems tedious and error-prone as it relies on manual docker image builds. This parameterization helps not only help identify the crucial setup variables for different teams but also help us toward the CI/CD process where there is no manual push is needed.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested using following command:
```
./build-image.sh v2xhub -v 0.0.2-with-plugin
```
Other usages:
```
./build-image.sh base -v 0.0.1
./build-image.sh build-general -v 0.0.1
./build-image.sh build-carla -v 0.0.1
./build-image.sh core -v 0.0.1
./build-image.sh v2xhub -v 0.0.1
./build-image.sh carla -v 0.0.1
./build-image.sh carla-0-9-15 -v 0.0.1
```
Also tag:
```
./build-image.sh core -v 0.0.1 --tag-latest
```
v2xhub with a non-default plugin branch
```
./build-image.sh v2xhub -v 0.0.1 --plugin-branch feature/my-branch
```
Build against specific tags anmd orgs:
```
DOCKER_ORG=distributed-testing-dev DOCKER_TAG=0.0.1 ./build-image.sh v2xhub -v 0.0.2 --plugin-branch develop
```
Also can target different stages of the v2xhub image (with tena plugin or not)
```
./build-image.sh v2xhub -v dev --target base
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
